### PR TITLE
Centralize DB configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+import os
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_db_path() -> str:
+    """Return the path to the SQLite database."""
+    env_path = os.environ.get("DB_PATH")
+    if env_path:
+        return env_path
+    docker_path = os.path.join('/app/data', 'metronome.db')
+    if os.path.exists(docker_path):
+        return docker_path
+    return os.path.join(ROOT_DIR, 'metronome.db')
+
+
+def get_sqlalchemy_uri() -> str:
+    """Return SQLAlchemy URI for the SQLite database."""
+    return f"sqlite:///{get_db_path()}"

--- a/src/flask_metronome.py
+++ b/src/flask_metronome.py
@@ -9,11 +9,10 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.database.models import db, Song, GuitarGoal, SongsterrLink
 from src.routes.song_routes import song_bp, init_db
+from config import get_sqlalchemy_uri
 
 app = Flask(__name__)
-# Utiliser un chemin dans le volume Docker pour la base de données
-db_path = os.path.join('/app/data', 'metronome.db')
-app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+app.config['SQLALCHEMY_DATABASE_URI'] = get_sqlalchemy_uri()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 # Initialiser la base de données

--- a/src/init_db.py
+++ b/src/init_db.py
@@ -1,13 +1,9 @@
-import os
-from database.models import db, Song
 from flask import Flask
-
-# Chemin absolu pour garantir la création dans le dossier metronome
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-DB_PATH = os.path.join(BASE_DIR, '..', 'metronome.db')
+from database.models import db, Song
+from config import get_sqlalchemy_uri
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DB_PATH}'
+app.config['SQLALCHEMY_DATABASE_URI'] = get_sqlalchemy_uri()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db.init_app(app)

--- a/upgrade_db.py
+++ b/upgrade_db.py
@@ -1,10 +1,7 @@
 import sqlite3
-import os
+from config import get_db_path
 
-default_path = '/app/data/metronome.db'
-if not os.path.exists(default_path):
-    default_path = 'metronome.db'
-DB_PATH = os.environ.get('DB_PATH', default_path)
+DB_PATH = get_db_path()
 
 conn = sqlite3.connect(DB_PATH)
 cur = conn.cursor()


### PR DESCRIPTION
## Summary
- create `config.py` with helper functions for DB path
- use the new configuration in `init_db.py`, `upgrade_db.py`, and `flask_metronome.py`

## Testing
- `python -m py_compile config.py src/init_db.py upgrade_db.py src/flask_metronome.py`

------
https://chatgpt.com/codex/tasks/task_e_68809f73a380832aaab5b7ae103a017b